### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ use std::io::prelude::*;
 fn main() {
     let mut shell = Shell::new(());
     shell.new_command_noargs("hello", "Say 'hello' to the world", |io, _| {
-        try!(writeln!(io, "Hello World !!!"));
+        writeln!(io, "Hello World !!!")?;
         Ok(())
     });
 
@@ -68,7 +68,7 @@ You can attach data to the shell for usage by commands as seen in [data.rs](./ex
 let v = Vec::new();
 let mut shell = Shell::new(v);
 shell.new_command("push", "Add string to the list", 1, |io, v, s| {
-    try!(writeln!(io, "Pushing {}", s[0]));
+    writeln!(io, "Pushing {}", s[0])?;
     v.push(s[0].to_string());
     Ok(())
 });


### PR DESCRIPTION
It looks like the `try!` keyword is invalid in newer versions of rust and replaced with the `?`.  I ran into this when trying to compile the example code here in the README.